### PR TITLE
Improved readyState handling

### DIFF
--- a/exploit.mjs
+++ b/exploit.mjs
@@ -667,11 +667,10 @@ function pop(event, save) {
 async function get_ready() {
     debug_log('readyState: ' + document.readyState);
     await new Promise((resolve, reject) => {
-        if (document.readyState !== "complete") {
-            document.addEventListener("DOMContentLoaded", resolve);
-            return;
+        if (document.readyState === 'interactive' || document.readyState === 'complete') {
+            resolve();
         }
-        resolve();
+        document.addEventListener('DOMContentLoaded', resolve, { once: true });
     });
 }
 


### PR DESCRIPTION
If the browser loads `exploit.js` during interactive readyState the exploit will not trigger.

This change just makes the exploit overall more constant. I tend to use this method for userscripts as it is much more reliable of an injection. https://github.com/magicoflolis/Userscript-Plus/blob/cfbf638faf05020447120c0f65fb9ad6c66a3688/src/UserJS/main.js#L2211