### PR TITLE
Prevent running kexploit more than once.

### DIFF
--- a/lapse.mjs
+++ b/lapse.mjs
@@ -1663,6 +1663,15 @@ export async function kexploit() {
     await init();
     const _init_t2 = performance.now();
 
+    // If setuid is successful, we dont need to run the kexploit again
+    try {
+        if (sysi('setuid', 0) == 0) {
+            log("Not running kexploit again.")
+            return;
+        }
+    }
+    catch (e) {}
+
     // fun fact:
     // if the first thing you do since boot is run the web browser, WebKit can
     // use all the cores


### PR DESCRIPTION
By adding a sysi call at the beginning of kexploit, We can prevent running the aio/lapse exploit more than once.

This ensures some more stability and the unnecessary need to run the kexploit again. This simply moves onto the payload loader.