### PR TITLE
Minor fixes: syntax issue and update cache manifest

### DIFF
--- a/lapse.mjs
+++ b/lapse.mjs
@@ -1705,7 +1705,6 @@ export async function kexploit() {
      try {
         chain.sys('setuid', 0);
         }
-    }
     catch (e) {
         localStorage.ExploitLoaded = "no";
     }

--- a/psfree_lapse.cache
+++ b/psfree_lapse.cache
@@ -8,7 +8,6 @@ config.mjs
 index.html
 lapse.mjs
 payload.bin
-payload.js
 psfree.mjs
 fonts\LiberationMono-Regular.ttf
 kpatch\900.elf


### PR DESCRIPTION
This pull request includes two changes related to the `lapse.mjs` file and the `psfree_lapse.cache` configuration file. The changes involve fixing a syntax issue in the exploit function and updating the list of cached files.

### Code Fixes:

* [`lapse.mjs`](diffhunk://#diff-01f5d17e99c29677c8bab09b6084785d3e96012dbcb46ea85fa6599ceff54800L1708): Corrected a syntax error by ensuring the closing brace for the `try` block is properly placed. This resolves a potential issue with the `kexploit` function.

### Configuration Updates:

* [`psfree_lapse.cache`](diffhunk://#diff-98a488980645cb463687f87f2349c7b24a88fbba9b6350436be4d87693092e29L11): Removed `payload.js` from the cached files list, likely to reflect updated project requirements or unused assets.